### PR TITLE
acme: implement ACME Renewal Info (ARI) extension

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -179,13 +179,14 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 	c.addNonce(res.Header)
 
 	var v struct {
-		Reg       string `json:"newAccount"`
-		Authz     string `json:"newAuthz"`
-		Order     string `json:"newOrder"`
-		Revoke    string `json:"revokeCert"`
-		Nonce     string `json:"newNonce"`
-		KeyChange string `json:"keyChange"`
-		Meta      struct {
+		Reg         string `json:"newAccount"`
+		Authz       string `json:"newAuthz"`
+		Order       string `json:"newOrder"`
+		Revoke      string `json:"revokeCert"`
+		Nonce       string `json:"newNonce"`
+		KeyChange   string `json:"keyChange"`
+		RenewalInfo string `json:"renewalInfo"`
+		Meta        struct {
 			Terms        string   `json:"termsOfService"`
 			Website      string   `json:"website"`
 			CAA          []string `json:"caaIdentities"`
@@ -205,6 +206,7 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		RevokeURL:               v.Revoke,
 		NonceURL:                v.Nonce,
 		KeyChangeURL:            v.KeyChange,
+		RenewalInfoURL:          v.RenewalInfo,
 		Terms:                   v.Meta.Terms,
 		Website:                 v.Meta.Website,
 		CAA:                     v.Meta.CAA,
@@ -255,6 +257,86 @@ func (c *Client) RevokeCert(ctx context.Context, key crypto.Signer, cert []byte,
 		return err
 	}
 	return c.revokeCertRFC(ctx, key, cert, reason)
+}
+
+// FetchRenewalInfo retrieves the RenewalInfo from Directory.RenewalInfoURL.
+func (c *Client) FetchRenewalInfo(ctx context.Context, leaf, issuer []byte) (*RenewalInfo, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
+	parsedLeaf, err := x509.ParseCertificate(leaf)
+	if err != nil {
+		return nil, err
+	}
+	parsedIssuer, err := x509.ParseCertificate(issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	renewalURL, err := c.getRenewalURL(parsedLeaf, parsedIssuer)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.get(ctx, renewalURL, wantStatus(http.StatusOK))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var info RenewalInfo
+	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func (c *Client) getRenewalURL(cert, issuer *x509.Certificate) (string, error) {
+	// See https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#name-getting-renewal-information
+	// for how the request URL is built.
+	var publicKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
+		return "", err
+	}
+
+	h := crypto.SHA256.New()
+	h.Write(publicKeyInfo.PublicKey.RightAlign())
+	issuerKeyHash := h.Sum(nil)
+
+	h.Reset()
+	h.Write(issuer.RawSubject)
+	issuerNameHash := h.Sum(nil)
+
+	// CertID ASN1 structure defined in
+	// https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
+	certID, err := asn1.Marshal(struct {
+		HashAlgorithm pkix.AlgorithmIdentifier
+		NameHash      []byte
+		IssuerKeyHash []byte
+		SerialNumber  *big.Int
+	}{
+		pkix.AlgorithmIdentifier{
+			// SHA256 OID
+			Algorithm:  asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1}),
+			Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
+		},
+		issuerNameHash,
+		issuerKeyHash,
+		cert.SerialNumber,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	url := c.dir.RenewalInfoURL
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	return url + base64.RawURLEncoding.EncodeToString(certID), nil
 }
 
 // AcceptTOS always returns true to indicate the acceptance of a CA's Terms of Service

--- a/acme/types.go
+++ b/acme/types.go
@@ -288,6 +288,10 @@ type Directory struct {
 	// KeyChangeURL allows to perform account key rollover flow.
 	KeyChangeURL string
 
+	// RenewalInfoURL allows to perform certificate renewal using the ACME
+	// Renewal Information (ARI) Extension.
+	RenewalInfoURL string
+
 	// Term is a URI identifying the current terms of service.
 	Terms string
 
@@ -612,3 +616,17 @@ func WithTemplate(t *x509.Certificate) CertOption {
 type certOptTemplate x509.Certificate
 
 func (*certOptTemplate) privateCertOpt() {}
+
+// RenewalInfoWindow describes the time frame during which the ACME client
+// should attempt to renew, using the ACME Renewal Info Extension.
+type RenewalInfoWindow struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// RenewalInfo describes the suggested renewal window for a given certificate,
+// returned from an ACME server, using the ACME Renewal Info Extension.
+type RenewalInfo struct {
+	SuggestedWindow RenewalInfoWindow `json:"suggestedWindow"`
+	ExplanationURL  string            `json:"explanationURL"`
+}


### PR DESCRIPTION
RFC draft: https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#name-getting-renewal-information
Allows an ACME client to query the ACME server for suggested renewal window for a specific certificate.

The code was authored by @noncombatant with a few of my fixes to `getRenewalURL`.