### PR TITLE
acme: rebase with latest changes

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -557,7 +557,11 @@ func (c *Client) Accept(ctx context.Context, chal *Challenge) (*Challenge, error
 		return nil, err
 	}
 
-	res, err := c.post(ctx, nil, chal.URI, json.RawMessage("{}"), wantStatus(
+	payload := json.RawMessage("{}")
+	if len(chal.Payload) != 0 {
+		payload = chal.Payload
+	}
+	res, err := c.post(ctx, nil, chal.URI, payload, wantStatus(
 		http.StatusOK,       // according to the spec
 		http.StatusAccepted, // Let's Encrypt: see https://goo.gl/WsJ7VT (acme-divergences.md)
 	))

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -875,7 +875,7 @@ func TestTLSALPN01ChallengeCert(t *testing.T) {
 }
 
 func TestTLSChallengeCertOpt(t *testing.T) {
-	key, err := rsa.GenerateKey(rand.Reader, 512)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acme/autocert/autocert_test.go
+++ b/acme/autocert/autocert_test.go
@@ -619,7 +619,7 @@ func TestCache(t *testing.T) {
 		PrivateKey:  ecdsaKey,
 	}
 
-	rsaKey, err := rsa.GenerateKey(rand.Reader, 512)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +694,7 @@ func TestValidCert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key3, err := rsa.GenerateKey(rand.Reader, 512)
+	key3, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acme/autocert/internal/acmetest/ca.go
+++ b/acme/autocert/internal/acmetest/ca.go
@@ -308,7 +308,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := decodePayload(&req, r.Body); err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 
@@ -328,7 +328,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 			Identifiers []struct{ Value string }
 		}
 		if err := decodePayload(&req, r.Body); err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 		ca.mu.Lock()
@@ -352,7 +352,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 		defer ca.mu.Unlock()
 		o, err := ca.storedOrder(strings.TrimPrefix(r.URL.Path, "/orders/"))
 		if err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 		if err := json.NewEncoder(w).Encode(o); err != nil {
@@ -412,7 +412,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 		orderID := strings.TrimPrefix(r.URL.Path, "/new-cert/")
 		o, err := ca.storedOrder(orderID)
 		if err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 		if o.Status != acme.StatusReady {
@@ -427,7 +427,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 		b, _ := base64.RawURLEncoding.DecodeString(req.CSR)
 		csr, err := x509.ParseCertificateRequest(b)
 		if err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 		// Issue the certificate.
@@ -449,7 +449,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 		defer ca.mu.Unlock()
 		o, err := ca.storedOrder(strings.TrimPrefix(r.URL.Path, "/issued-cert/"))
 		if err != nil {
-			ca.httpErrorf(w, http.StatusBadRequest, err.Error())
+			ca.httpErrorf(w, http.StatusBadRequest, "%v", err)
 			return
 		}
 		if o.Status != acme.StatusValid {

--- a/acme/types.go
+++ b/acme/types.go
@@ -7,6 +7,7 @@ package acme
 import (
 	"crypto"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -292,7 +293,7 @@ type Directory struct {
 	// Renewal Information (ARI) Extension.
 	RenewalInfoURL string
 
-	// Term is a URI identifying the current terms of service.
+	// Terms is a URI identifying the current terms of service.
 	Terms string
 
 	// Website is an HTTP or HTTPS URL locating a website
@@ -531,6 +532,16 @@ type Challenge struct {
 	// when this challenge was used.
 	// The type of a non-nil value is *Error.
 	Error error
+
+	// Payload is the JSON-formatted payload that the client sends
+	// to the server to indicate it is ready to respond to the challenge.
+	// When unset, it defaults to an empty JSON object: {}.
+	// For most challenges, the client must not set Payload,
+	// see https://tools.ietf.org/html/rfc8555#section-7.5.1.
+	// Payload is used only for newer challenges (such as "device-attest-01")
+	// where the client must send additional data for the server to validate
+	// the challenge.
+	Payload json.RawMessage
 }
 
 // wireChallenge is ACME JSON challenge representation.


### PR DESCRIPTION
Pull in latest changes in acme/ to make it compatible with 1.24 (specifically - the test RSA key sizes).

Updates #15015