### PR TITLE
acme: add "replaces" support to AuthorizeOrder

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -270,10 +270,7 @@ func (c *Client) FetchRenewalInfo(ctx context.Context, leaf []byte) (*RenewalInf
 		return nil, fmt.Errorf("parsing leaf certificate: %w", err)
 	}
 
-	renewalURL, err := c.getRenewalURL(parsedLeaf)
-	if err != nil {
-		return nil, fmt.Errorf("generating renewal info URL: %w", err)
-	}
+	renewalURL := c.getRenewalURL(parsedLeaf)
 
 	res, err := c.get(ctx, renewalURL, wantStatus(http.StatusOK))
 	if err != nil {
@@ -288,16 +285,20 @@ func (c *Client) FetchRenewalInfo(ctx context.Context, leaf []byte) (*RenewalInf
 	return &info, nil
 }
 
-func (c *Client) getRenewalURL(cert *x509.Certificate) (string, error) {
+func (c *Client) getRenewalURL(cert *x509.Certificate) string {
 	// See https://www.ietf.org/archive/id/draft-ietf-acme-ari-04.html#name-the-renewalinfo-resource
 	// for how the request URL is built.
 	url := c.dir.RenewalInfoURL
 	if !strings.HasSuffix(url, "/") {
 		url += "/"
 	}
+	return url + certRenewalIdentifier(cert)
+}
+
+func certRenewalIdentifier(cert *x509.Certificate) string {
 	aki := base64.RawURLEncoding.EncodeToString(cert.AuthorityKeyId)
 	serial := base64.RawURLEncoding.EncodeToString(cert.SerialNumber.Bytes())
-	return fmt.Sprintf("%s%s.%s", url, aki, serial), nil
+	return aki + "." + serial
 }
 
 // AcceptTOS always returns true to indicate the acceptance of a CA's Terms of Service

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -549,10 +549,7 @@ func TestGetRenewalURL(t *testing.T) {
 	}
 
 	client := newTestClientWithMockDirectory()
-	urlString, err := client.getRenewalURL(parsedLeaf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	urlString := client.getRenewalURL(parsedLeaf)
 
 	parsedURL, err := url.Parse(urlString)
 	if err != nil {

--- a/acme/rfc8555_test.go
+++ b/acme/rfc8555_test.go
@@ -766,10 +766,17 @@ func TestRFC_AuthorizeOrder(t *testing.T) {
 	s.start()
 	defer s.close()
 
+	prevCertDER, _ := pem.Decode([]byte(leafPEM))
+	prevCert, err := x509.ParseCertificate(prevCertDER.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cl := &Client{Key: testKeyEC, DirectoryURL: s.url("/")}
 	o, err := cl.AuthorizeOrder(context.Background(), DomainIDs("example.org"),
 		WithOrderNotBefore(time.Date(2019, 8, 31, 0, 0, 0, 0, time.UTC)),
 		WithOrderNotAfter(time.Date(2019, 9, 2, 0, 0, 0, 0, time.UTC)),
+		WithOrderReplacesCert(prevCert),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/acme/types.go
+++ b/acme/types.go
@@ -391,6 +391,30 @@ type orderNotAfterOpt time.Time
 
 func (orderNotAfterOpt) privateOrderOpt() {}
 
+// WithOrderReplacesCert indicates that this Order is for a replacement of an
+// existing certificate.
+// See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
+func WithOrderReplacesCert(cert *x509.Certificate) OrderOption {
+	return orderReplacesCert{cert}
+}
+
+type orderReplacesCert struct {
+	cert *x509.Certificate
+}
+
+func (orderReplacesCert) privateOrderOpt() {}
+
+// WithOrderReplacesCertDER indicates that this Order is for a replacement of
+// an existing DER-encoded certificate.
+// See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
+func WithOrderReplacesCertDER(der []byte) OrderOption {
+	return orderReplacesCertDER(der)
+}
+
+type orderReplacesCertDER []byte
+
+func (orderReplacesCertDER) privateOrderOpt() {}
+
 // Authorization encodes an authorization response.
 type Authorization struct {
 	// URI uniquely identifies a authorization.


### PR DESCRIPTION
This field indicates which certificate is being replaced via ARI. Setting it enforces additional checks that certificates are indeed related, and in return excludes the order from rate limits.

See https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients/#step-6-indicating-which-certificate-is-replaced-by-this-new-order